### PR TITLE
Misc script fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 Proof-of-Concept/experiments with integrating Java modules (`jlink`,`jdep`)
 and OpenShift.
 
+## Prerequisites
+
+Most of the scripts require `$JAVA_HOME` to be defined.
+
+## Script details
+
  * `mkdeps.sh`:          springboot demo   → jdeps     → deps.txt
  * `mkquarkusdeps.sh`:   quarkus demo      → jdeps     → deps.txt
  * `mkstrippeddeps.sh`:  deps.txt          → filtering → stripped-deps.txt
@@ -11,3 +17,4 @@ and OpenShift.
 
  * `repack_jdk.sh`: replaced non-stripped libs from a JDK image with stripped ones from system JDK
  * `merged-script.sh`: jdeps → deps.txt → filtering → stripped-deps.txt → filtering → module-deps.txt → jlink
+

--- a/generatejdkdeps.sh
+++ b/generatejdkdeps.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-JAVA_HOME="/lib/jvm/java-11-openjdk/bin"
-
-$JAVA_HOME/java --list-modules > java-modules.txt
-cat java-modules.txt | sed "s/\\@.*//" > modules.txt
+$JAVA_HOME/bin/java --list-modules > java-modules.txt
+< java-modules.txt sed "s/\\@.*//" > modules.txt
 grep -Fx -f stripped-deps.txt modules.txt | tr '\n' ',' | tr -d "[:space:]" > module-deps.txt
 echo "jdk.zipfs" >> module-deps.txt

--- a/mkdeps.sh
+++ b/mkdeps.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 shopt -s globstar
 
-project="spring-boot-sample-simple"
-jarfile="$project/target/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar"
-libdir="$project/target/lib"
+project="${project-spring-boot-sample-simple}"
+jarfile="${jarfile-$project/target/spring-boot-sample-simple-1.5.0.BUILD-SNAPSHOT.jar}"
+libdir="${libdir-$project/target/lib}"
 
 test -f "$jarfile"
 test -d "$libdir"

--- a/mkjreimage.sh
+++ b/mkjreimage.sh
@@ -7,4 +7,5 @@ test -f $depsfile
 
 $JAVA_HOME/bin/jlink --output spring-boot-jre \
        	--add-modules (cat $depsfile) \
-	--strip-debug --no-header-files --no-man-pages
+	--strip-debug --no-header-files --no-man-pages \
+	--compress=2

--- a/mkjreimage.sh
+++ b/mkjreimage.sh
@@ -7,4 +7,4 @@ test -f $depsfile
 
 $JAVA_HOME/bin/jlink --output spring-boot-jre \
        	--add-modules (cat $depsfile) \
-	-G --no-header-files --no-man-pages
+	--strip-debug --no-header-files --no-man-pages

--- a/mkquarkusdeps.sh
+++ b/mkquarkusdeps.sh
@@ -2,10 +2,9 @@
 set -euo pipefail
 shopt -s globstar
 
-project="quarkus-quickstart/getting-started"
-jarfile="$project/target/quarkus-app/quarkus-run.jar"
-libdir="$project/target/quarkus-app/lib"
-JAVA_HOME="/lib/jvm/java-11-openjdk"
+project="${project-quarkus-quickstart/getting-started}"
+jarfile="${jarfile-$project/target/quarkus-app/quarkus-run.jar}"
+libdir="${libdir-$project/target/quarkus-app/lib}"
 
 test -f "$jarfile"
 test -d "$libdir"


### PR DESCRIPTION
These are a small set of script fix-ups and quality of life improvements

 * various variables are adjusted so they can be overridden when the script is invoked (e.g. `project=foo bash mkdeps.sh`)
 *  don't define `JAVA_HOME` anywhere and rely on it being set correctly in the environment
 * use long options for `jlink` for self-documentation
 * enable ZIP compression on `jlink` output