### PR TITLE
baseline: script for gathering baseline img sizes

### DIFF
--- a/baseline/README.md
+++ b/baseline/README.md
@@ -1,0 +1,21 @@
+# jlink-openshift Baseline
+
+This script uses S2I to build a Java web application using the
+traditional S2I workflow which layers the result on top of the
+builder image.
+
+We use the [Red Hat OpenJDK
+containers](https://github.com/jboss-container-images/openjdk) as
+the builder image and [Source to
+Image](http://github.com/openshift/source-to-image).
+
+We specify the following environment variables to tune the build:
+
+ * **S2I_DELETE_SOURCE=true, MAVEN_CLEAR_REPO=true**
+   * these reduce the resulting image size by removing the source
+     and intermediate build artefacts.
+ * **QUARKUS_PACKAGE_TYPE=uber-jar, MAVEN_S2I_ARTIFACT_DIRS=target, S2I_SOURCE_DEPLOYMENTS_FILTER="*.jar", JAVA_APP_JAR=**
+   * These are necessary to override alternative values supplied by the
+     application sources in the `.s2i/environment` file which otherwise
+     configure the image for the `fast-jar` build layout.
+ 

--- a/baseline/baseline.sh
+++ b/baseline/baseline.sh
@@ -1,0 +1,24 @@
+#!/bin.bash
+set -euo pipefail
+
+# Baseline S2I app build (app layered on top of builder image)
+
+BASEIMG=${BASEIMG:=registry.access.redhat.com/ubi8/openjdk-17:1.15-1.1682053058}
+APPSRC=${APPSRC:=https://github.com/quarkusio/quarkus-quickstarts.git}
+CONTEXTDIR=${CONTEXTDIR:=getting-started}
+rev=${rev:=2.16.4.Final}
+rev=3.0.3.Final
+OUTIMG=jlink-baseline:$rev
+
+s2i build --pull-policy if-not-present --context-dir=$CONTEXTDIR -r=${rev} \
+    -e S2I_DELETE_SOURCE=true \
+    -e MAVEN_CLEAR_REPO=true \
+    -e QUARKUS_PACKAGE_TYPE=uber-jar \
+    -e MAVEN_S2I_ARTIFACT_DIRS=target \
+    -e S2I_SOURCE_DEPLOYMENTS_FILTER="*.jar" \
+    -e JAVA_APP_JAR= \
+    $APPSRC \
+    $BASEIMG \
+    $OUTIMG
+
+docker save $OUTIMG | wc -c


### PR DESCRIPTION
the parameters we want for baseline are subtly different to what's in `buildapp` so I've put them in a separate script. I've also added the method used to measure image size in bytes (`docker save ... | wc -c`). 